### PR TITLE
Adds lifecycle events

### DIFF
--- a/framework/base/BaseObject.php
+++ b/framework/base/BaseObject.php
@@ -77,6 +77,18 @@ use Yii;
 class BaseObject implements Configurable
 {
     /**
+     * @event ComponentEvent The event that is triggered befote the component's init cycle
+     */
+    const EVENT_BEFORE_INIT = 'beforeInit';
+    
+    /**
+     * @event ComponentEvent The event that is triggered after the component's init cycle
+     *
+     * This is a good place to register custom behaviors on the component
+     */
+    const EVENT_AFTER_INIT = 'afterInit';
+    
+    /**
      * Returns the fully qualified name of this class.
      * @return string the fully qualified name of this class.
      */
@@ -104,7 +116,9 @@ class BaseObject implements Configurable
         if (!empty($config)) {
             Yii::configure($this, $config);
         }
+        $this->trigger(self::EVENT_BEFORE_INIT, new \yii\base\Event);
         $this->init();
+        $this->trigger(self::EVENT_AFTER_INIT, new \yii\base\Event);
     }
 
     /**


### PR DESCRIPTION
Adds events to all components so you may hook into their `init` without modifying the class code.

There a many uses for these events and I admit I may not be thinking of all of them. My primary reason for needing this is to add behaviors to objects that I don't control the instantiation of.

E.g., in Craft (a CMS built on Yii), I can't control the generation of `Field` objects while writing a plugin for the CMS. Because of this there's no good place to add a `Behavior` to the `Field`.

With component lifecycle events I can do something like this, though, to add behaviors every time a `Field` is instantiated:

```php
Event::on(Field::className(), Field::EVENT_AFTER_INIT, function ($event) {
  $event->sender->attachBehavior('myBehavior', MyBehavior::class);
});
```
You can see a related PR for Craft here: https://github.com/craftcms/cms/pull/1856#issuecomment-317914044


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none
